### PR TITLE
chore(db): adicionar schema.sql e seed.sql com estrutura inicial do b…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,35 @@
+## ⚠️ Aviso Legal
+
+> ⚠️ **Este projeto é de uso privado.**  
+> Não é permitido copiar, redistribuir ou publicar este código sem autorização expressa do autor.  
+> Todos os direitos reservados a Thiago Vinicios Anacleto A. P.
+
+# Suporte
+
+Esté é um Sistema de chamados técnicos interno, desenvolvido em Python com Flask, para controle e acompanhamento de chamados, empresas, máquinas e ações técnicas.
+
+---
+
+## 🚀 Funcionalidades
+
+- Abertura e edição de chamados
+- Histórico automático de alterações
+- Cadastro de empresas, máquinas e origens do problema
+- Dashboard dinâmico com contadores e gráficos
+- Chamados recorrentes automáticos
+- Controle de usuários com níveis de privilégio
+- Suporte a múltiplos ambientes (dev/prod) com PostgreSQL (Neon.tech)
+- Deploy automatizado com Railway
+
+---
+
+## 🛠️ Tecnologias
+
+- **Backend:** Python (Flask)
+- **Banco de Dados:** PostgreSQL (via Neon.tech)
+- **Deploy:** Railway
+- **Interface:** HTML + CSS (com templates Jinja2)
+
+## 📬 Contato
+
+Caso tenha interesse legítimo em colaborar ou saber mais, entre em contato via [GitHub](https://github.com/ThiagoViniciosAnacleto/) ou thiagoanacletonn3@gmail.com

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,76 @@
+
+-- Tabela: usuarios
+CREATE TABLE IF NOT EXISTS usuarios (
+    id SERIAL PRIMARY KEY,
+    usuario TEXT UNIQUE,
+    senha_hash TEXT,
+    is_admin INTEGER
+);
+
+-- Tabela: empresas
+CREATE TABLE IF NOT EXISTS empresas (
+    id SERIAL PRIMARY KEY,
+    nome TEXT UNIQUE NOT NULL
+);
+
+-- Tabela: maquinas
+CREATE TABLE IF NOT EXISTS maquinas (
+    id SERIAL PRIMARY KEY,
+    modelo TEXT UNIQUE NOT NULL
+);
+
+-- Tabela: origens_problema
+CREATE TABLE IF NOT EXISTS origens_problema (
+    id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    nome TEXT UNIQUE NOT NULL
+);
+
+-- Tabela: chamados
+CREATE TABLE IF NOT EXISTS chamados (
+    id SERIAL PRIMARY KEY,
+    responsavel_atendimento TEXT,
+    data TEXT,
+    horario TEXT,
+    cliente TEXT,
+    empresa TEXT,
+    porta_ssh TEXT,
+    tipo_maquina TEXT,
+    relato TEXT,
+    prioridade TEXT,
+    origem TEXT,
+    responsavel_acao TEXT,
+    descricao_acao TEXT,
+    status TEXT
+);
+
+-- Tabela: chamados_recorrentes
+CREATE TABLE IF NOT EXISTS chamados_recorrentes (
+    id SERIAL PRIMARY KEY,
+    cliente TEXT NOT NULL,
+    empresa TEXT,
+    porta_ssh TEXT,
+    tipo_maquina TEXT,
+    relato TEXT NOT NULL,
+    prioridade TEXT,
+    origem TEXT,
+    responsavel_atendimento TEXT,
+    responsavel_acao TEXT,
+    descricao_acao TEXT,
+    frequencia TEXT CHECK (frequencia = ANY (ARRAY['diaria', 'semanal', 'mensal'])),
+    proxima_execucao DATE NOT NULL,
+    ativo BOOLEAN DEFAULT true
+);
+
+-- Tabela: log_acoes
+CREATE TABLE IF NOT EXISTS log_acoes (
+    id SERIAL PRIMARY KEY,
+    usuario_id INTEGER,
+    acao TEXT NOT NULL,
+    chamado_id INTEGER,
+    data_hora TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    tipo TEXT,
+    campo TEXT,
+    valor_antigo TEXT,
+    valor_novo TEXT,
+    CONSTRAINT log_acoes_usuario_id_fkey FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+);

--- a/sql/seed.sql
+++ b/sql/seed.sql
@@ -1,0 +1,62 @@
+-- Popular empresas
+INSERT INTO empresas (nome) VALUES
+('Cenci'),
+('Nortel'),
+('Horsch'),
+('Seco Tools'),
+('2S'),
+('Frontiere'),
+('Nexeed do Brasil'),
+('Dimensional'),
+('Time Machine'),
+('Wurth'),
+('TKK'),
+('Escola Moranguinho'),
+('Jor Machines'),
+('Usiminas'),
+('Mazaj'),
+('Wtec'),
+('Hinty'),
+('Sayerlack'),
+('Light Food'),
+('Redumax'),
+('AutoSupply'),
+('Scania'),
+('CTC'),
+('WonderBox'),
+('Hexion'),
+('ProntoLight'),
+('Agco'),
+('Selaria Faísca'),
+('Procoat'),
+('Liberty Telecom'),
+('Sandra Queiroz'),
+('Neobetel'),
+('Fardas Uniformes')
+ON CONFLICT (nome) DO NOTHING;
+
+-- Popular máquinas
+INSERT INTO maquinas (modelo) VALUES
+('Storage'),
+('Stockage'),
+('Carrossel'),
+('Smart Slim'),
+('Locker')
+ON CONFLICT (modelo) DO NOTHING;
+
+-- Popular origens do problema
+INSERT INTO origens_problema (nome) VALUES
+('Eletrônico'),
+('Rede'),
+('Instalação'),
+('Sistema Storage'),
+('Sistema Externo'),
+('Sistema Slim'),
+('Sistema Embarcado'),
+('Comercial'),
+('Mecânico'),
+('Refrigeração'),
+('Elétrico'),
+('Stone'),
+('Outros')
+ON CONFLICT (nome) DO NOTHING;


### PR DESCRIPTION
…anco

- Adiciona o arquivo sql/schema.sql contendo os comandos de criação das tabelas do sistema.
- Adiciona o arquivo sql/seed.sql para popular as tabelas empresas, maquinas e origens_problema com dados iniciais.
- Atualiza o README com informações sobre o projeto e aviso legal de uso privado.

Esses arquivos facilitam a criação e replicação da estrutura do banco em novos ambientes (como dev/prod).